### PR TITLE
Universal APK - User Input to set IP address

### DIFF
--- a/PieMessage-Android/app/src/main/AndroidManifest.xml
+++ b/PieMessage-Android/app/src/main/AndroidManifest.xml
@@ -28,9 +28,6 @@
         </activity>
 
         <service
-            android:name=".Legacy.ReceiveMessagesLegacyService"
-            android:exported="false" />
-        <service
             android:name="com.ericchee.bboyairwreck.piemessage.ReceiveMessagesService"
             android:exported="false" />
 

--- a/PieMessage-Android/app/src/main/AndroidManifest.xml
+++ b/PieMessage-Android/app/src/main/AndroidManifest.xml
@@ -5,32 +5,40 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:name="com.ericchee.bboyairwreck.piemessage.PieMessageApplication"
+        android:name=".PieMessageApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name="com.ericchee.bboyairwreck.piemessage.MessageActivity"
+            android:name=".MessageActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
-        </activity>
+            android:theme="@style/AppTheme.NoActionBar" />
         <activity
-            android:name="com.ericchee.bboyairwreck.piemessage.ChatsActivity"
+            android:name=".ChatsActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme"
-            >
+            android:theme="@style/AppTheme">
+        </activity>
+
+        <service
+            android:name=".ReceiveMessagesService"
+            android:exported="false" />
+
+        <activity android:name=".MainActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
-        <service
-            android:name="com.ericchee.bboyairwreck.piemessage.ReceiveMessagesService"
-            android:exported="false" />
-
+        <activity android:name=".PiePreferenceActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme"
+            />
     </application>
 
 </manifest>

--- a/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/ChatsActivity.java
+++ b/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/ChatsActivity.java
@@ -27,6 +27,8 @@ public class ChatsActivity extends AppCompatActivity implements ReceiveMessagesS
     ReceiveMessagesService receiveMessagesService;
     private boolean boundReceiveService = false;
 
+    private static final int SETTINGS_RESULT = 1;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -148,6 +150,8 @@ public class ChatsActivity extends AppCompatActivity implements ReceiveMessagesS
 
         //noinspection SimplifiableIfStatement
         if (id == R.id.action_settings) {
+            Intent piePreferenceIntent = new Intent(this, PiePreferenceActivity.class);
+            startActivityForResult(piePreferenceIntent, SETTINGS_RESULT);
             return true;
         }
 

--- a/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/Constants.java
+++ b/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/Constants.java
@@ -4,8 +4,6 @@ package com.ericchee.bboyairwreck.piemessage;
  * Created by eric on 12/8/15.
  */
 public class Constants {
-    public static final String socketAddress = "127.0.0.1"; // INSERT YOUR PUBLIC IP HERE linked to OSX Client
-
     public static final String chatROWID = "chat_rowid";
     public static final String chatHandlesString = "chatHandlesString";
 }

--- a/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/MainActivity.java
+++ b/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/MainActivity.java
@@ -1,0 +1,90 @@
+package com.ericchee.bboyairwreck.piemessage;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Toast;
+
+public class MainActivity extends AppCompatActivity {
+    private String prefSocketAddressKey;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+        this.prefSocketAddressKey = getString(R.string.pref_socket_address_key);
+
+        // Check if Set IP Address
+        if (!sharedPreferences.contains(prefSocketAddressKey)) {
+            // Show IP Set up
+            setContentView(R.layout.activity_main);
+            sharedPreferences.getString(prefSocketAddressKey, "127.0.0.1");
+
+            Button btnStartPie = (Button) findViewById(R.id.btnStartPie);
+            btnStartPie.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    // Get value and
+                    EditText etSocketAddress = (EditText) findViewById(R.id.etSocketAddress);
+
+                    // Check if IP is valid string
+                    if (validIP(etSocketAddress.getText().toString().trim())) {
+                        // Save preference
+                        SharedPreferences.Editor editor = sharedPreferences.edit();
+                        editor.putString(prefSocketAddressKey, etSocketAddress.getText().toString().trim());
+                        editor.apply();
+
+                        // Start ReceiveMessagesService and load ChatActivity
+                        PieMessageApplication.getInstance().startReceieveMessagesService();
+                        startChatActivity();
+                    } else {
+                        CharSequence text = "In valid IP address";
+                        Toast.makeText(MainActivity.this, text, Toast.LENGTH_SHORT).show();
+                    }
+                }
+            });
+        } else {
+            // Load to ChatActivity
+            startChatActivity();
+        }
+
+    }
+
+    public static boolean validIP (String ip) {
+        try {
+            if ( ip == null || ip.isEmpty() ) {
+                return false;
+            }
+
+            String[] parts = ip.split( "\\." );
+            if ( parts.length != 4 ) {
+                return false;
+            }
+
+            for ( String s : parts ) {
+                int i = Integer.parseInt( s );
+                if ( (i < 0) || (i > 255) ) {
+                    return false;
+                }
+            }
+            if ( ip.endsWith(".") ) {
+                return false;
+            }
+
+            return true;
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
+
+    private void startChatActivity() {
+        Intent chatActivityIntent = new Intent(this, ChatsActivity.class);
+        startActivity(chatActivityIntent);
+        finish();
+    }
+}

--- a/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/PieMessageApplication.java
+++ b/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/PieMessageApplication.java
@@ -2,6 +2,8 @@ package com.ericchee.bboyairwreck.piemessage;
 
 import android.app.Application;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import java.util.TreeMap;
@@ -39,6 +41,14 @@ public class PieMessageApplication extends Application {
         chatsMap = new TreeMap<>();
         dbHelper.getAllChats();
 
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+
+        if (sharedPreferences.contains(getString(R.string.pref_socket_address_key))) {
+            startReceieveMessagesService();
+        }
+    }
+
+    public void startReceieveMessagesService() {
         Intent receiveService = new Intent(this, ReceiveMessagesService.class);
         startService(receiveService);
     }

--- a/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/PiePreferenceActivity.java
+++ b/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/PiePreferenceActivity.java
@@ -1,0 +1,61 @@
+package com.ericchee.bboyairwreck.piemessage;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.EditTextPreference;
+import android.preference.Preference;
+import android.preference.PreferenceFragment;
+import android.preference.PreferenceManager;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.util.Log;
+
+public class PiePreferenceActivity extends android.preference.PreferenceActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getFragmentManager().beginTransaction().replace(android.R.id.content, new PiePreferenceFragment()).commit();
+    }
+
+    public static class PiePreferenceFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
+        private static final String TAG = PiePreferenceFragment.class.getSimpleName();
+
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            // Load user settings xml resource
+            addPreferencesFromResource(R.xml.user_settings);
+            updateSocketAddressSummary(findPreference(getString(R.string.pref_socket_address_key)));
+        }
+
+        @Override
+        public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+            Preference pref = findPreference(key);
+
+            Log.i(TAG, "Preference change detected");
+            if (pref instanceof EditTextPreference && key.equals(getString(R.string.pref_socket_address_key))) {
+                Log.i(TAG, "Setting IP address");
+
+                PieMessageApplication.getInstance().stopService(new Intent(getActivity(), ReceiveMessagesService.class));
+                PieMessageApplication.getInstance().startReceieveMessagesService();
+
+                updateSocketAddressSummary(pref);
+            }
+        }
+
+        private void updateSocketAddressSummary(Preference pref) {
+            EditTextPreference editTextPreference = (EditTextPreference) pref;
+            pref.setSummary(editTextPreference.getText());
+        }
+
+        @Override
+        public void onAttach(Activity activity) {
+            super.onAttach(activity);
+            PreferenceManager.getDefaultSharedPreferences(activity).registerOnSharedPreferenceChangeListener(this);
+        }
+    }
+
+
+}

--- a/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/ReceiveMessagesService.java
+++ b/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/ReceiveMessagesService.java
@@ -8,11 +8,13 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.content.SharedPreferences;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Binder;
 import android.os.IBinder;
+import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.TaskStackBuilder;
 import android.util.Log;
@@ -67,7 +69,9 @@ public class ReceiveMessagesService extends IntentService {
 
             Log.i(TAG, "onHandleIntent");
             try {
-                socket = new Socket(Constants.socketAddress, 5000);
+                SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+                String socketAddress = sharedPreferences.getString(getString(R.string.pref_socket_address_key), "127.0.0.1");
+                socket = new Socket(socketAddress, 5000);
                 PrintWriter output = new PrintWriter(socket.getOutputStream(), true);
                 BufferedReader input = new BufferedReader(new InputStreamReader(socket.getInputStream()));
 

--- a/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/SendMessageTask.java
+++ b/PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/SendMessageTask.java
@@ -1,6 +1,8 @@
 package com.ericchee.bboyairwreck.piemessage;
 
+import android.content.SharedPreferences;
 import android.os.AsyncTask;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import org.json.JSONException;
@@ -33,7 +35,9 @@ public class SendMessageTask extends AsyncTask {
 
         try {
             Log.i(TAG, "Entering Client");
-            socket = new Socket(Constants.socketAddress, 5000);
+            SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this.activity);
+            String socketAddress = sharedPreferences.getString(activity.getString(R.string.pref_socket_address_key), "127.0.0.1");
+            socket = new Socket(socketAddress, 5000);
             PrintWriter output = new PrintWriter(socket.getOutputStream(), true);
             BufferedReader input = new BufferedReader(new InputStreamReader(socket.getInputStream()));
 

--- a/PieMessage-Android/app/src/main/res/layout/activity_main.xml
+++ b/PieMessage-Android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context="com.ericchee.bboyairwreck.piemessage.MainActivity"
+    android:background="#4b0a8e"
+    >
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="30dp"
+        >
+
+        <TextView
+            android:id="@+id/tvWelcomeTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:text="@string/welcome_title"
+            android:textSize="40dp"
+            android:textColor="@color/white"
+            android:textAlignment="center"
+            />
+
+        <TextView
+            android:id="@+id/tvEnterOSXIPAddress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tvWelcomeTitle"
+            android:layout_marginTop="60dp"
+            android:layout_centerHorizontal="true"
+            android:textSize="20dp"
+            android:textAlignment="center"
+            android:textColor="@color/white"
+            android:text="Please enter the OSX Client's IP Address"
+            />
+        <EditText
+            android:id="@+id/etSocketAddress"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/tvEnterOSXIPAddress"
+            android:layout_marginTop="10dp"
+            android:hint="ex. 127.0.0.1"
+            android:textColor="@color/white"
+            android:textColorHint="@color/grey"
+            tools:text="127.0.0.1"
+            android:textAlignment="center"
+            />
+    </RelativeLayout>
+
+    <Button
+        android:id="@+id/btnStartPie"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Pie Me!"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentRight="true"
+        />
+
+</RelativeLayout>

--- a/PieMessage-Android/app/src/main/res/values/strings.xml
+++ b/PieMessage-Android/app/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
     <string name="title_activity_conversation">ConversationActivity</string>
 
     <string name="hello_world">Hello world!</string>
+    <string name="pref_socket_address_key">prefSocketAddress</string>
+    <string name="welcome_title">Welcome to\nPie Message!</string>
 </resources>

--- a/PieMessage-Android/app/src/main/res/xml/user_settings.xml
+++ b/PieMessage-Android/app/src/main/res/xml/user_settings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceCategory android:title="Settings">
+        <EditTextPreference
+            android:title="Socket IP address"
+            android:summary="Set your OSX Client's IP address"
+            android:key="@string/pref_socket_address_key"
+            />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ The [Android client](./PieMessage-Android/) connects to a socket that whose IP a
 1. Open the Messages application and add your iCloud account in Messages > Preferences > Accounts.
 2. Clone the PieMessage project onto your OSX Device.
 3. Edit the *socketAddress* value in [PieOSXClient/src/Constants.java](./PieOSXClient/src/Constants.java) to your public IP address that is linked to your OSX device.
-4. Edit the *socketAddress* value in [/app/.../Constants.java](./PieMessage-Android/app/src/main/java/com/ericchee/bboyairwreck/piemessage/Constants.java) to your public IP address that is linked to your OSX device.
 
 You can do either terminal or GUI setup from here. If you will be working on this you will eventually need to set it up in IntelliJ/Android Studio or get it to work in your IDE of choice.
 


### PR DESCRIPTION
Eric, developer of PieMessage here. I have successfully created a universal APK for people to use. In theory, we can skip the need for testers to compile completely.
- No more need to edit Constants.java
- Added MainActivity that will show on first-time launch of app
- EditText that asks for OSX Client's IP address
- Added PreferenceActivity/Fragment to edit the IP Address preference

This has already been tested. I was able to switch between two Macbooks dynamically by editing IP address within the app's preference menu.

Let me know what you guys think. Gimme a thumbs up and I'll merge it.
